### PR TITLE
EditorScreen 및 DrawManager 업데이트

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -228,6 +228,13 @@ public final class Core {
 				returnCode = frame.setScreen(currentScreen);
 				LOGGER.info("Closing editor screen.");
 				break;
+			case 10:
+				// Playable Ship Editor
+				currentScreen = new PlayableShipEditor(width, height, FPS);
+				LOGGER.info("Starting Playable Ship Editor screen.");
+				returnCode = frame.setScreen(currentScreen);
+				LOGGER.info("Closing Playable Ship Editor screen.");
+				break;
 			default:
 				break;
 			}

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -2056,4 +2056,21 @@ public final class DrawManager {
 
 		}
 	}
+
+    /**
+     * Draws the editor screen.
+     *
+     * @param screen
+     *            Screen to draw on.
+     */
+    public void drawEditor(final Screen screen) {
+        String editorTitle = "Editor Mode"; // 에디터 모드 타이틀
+
+        // 타이틀을 초록색으로 중앙에 그리기
+        backBufferGraphics.setColor(Color.GREEN);
+        drawCenteredBigString(screen, editorTitle, screen.getHeight() / 4);
+
+        // 추가적인 에디터 화면 요소를 그릴 수 있습니다.
+        // 예를 들어, 사용자가 편집할 수 있는 요소나 도구 등을 그릴 수 있습니다.
+    }
 }

--- a/src/screen/EditorScreen.java
+++ b/src/screen/EditorScreen.java
@@ -4,6 +4,7 @@ import engine.Core;
 import engine.InputManager;
 import engine.SoundManager;
 import engine.Sound;
+import engine.Cooldown;
 
 import java.awt.event.KeyEvent;
 
@@ -14,6 +15,14 @@ public class EditorScreen extends Screen {
 
     /** Singleton instance of SoundManager */
     private final SoundManager soundManager = SoundManager.getInstance();
+    /** Selected row. */
+    private int selectedRow;
+    /** Total number of rows for selection. */
+    private static final int TOTAL_ROWS = 2; // Playable Ship Features, Enemy Ship Features
+    /** Time between changes in user selection. */
+    private final Cooldown selectionCooldown;
+    /** Milliseconds between changes in user selection. */
+    private static final int SELECTION_TIME = 200;
 
     /**
      * Constructor, establishes the properties of the screen.
@@ -27,6 +36,9 @@ public class EditorScreen extends Screen {
      */
     public EditorScreen(final int width, final int height, final int fps) {
         super(width, height, fps);
+        this.selectedRow = 0;
+        this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
+        this.selectionCooldown.reset();
     }
 
     /**
@@ -46,14 +58,36 @@ public class EditorScreen extends Screen {
         super.update();
 
         draw();
-        if (this.inputDelay.checkFinished()) {
+        if (this.inputDelay.checkFinished() && this.selectionCooldown.checkFinished()) {
+            if (inputManager.isKeyDown(KeyEvent.VK_UP)) {
+                this.selectedRow = (this.selectedRow - 1 + TOTAL_ROWS) % TOTAL_ROWS;
+                this.selectionCooldown.reset();
+                soundManager.playSound(Sound.MENU_MOVE);
+            } else if (inputManager.isKeyDown(KeyEvent.VK_DOWN)) {
+                this.selectedRow = (this.selectedRow + 1) % TOTAL_ROWS;
+                this.selectionCooldown.reset();
+                soundManager.playSound(Sound.MENU_MOVE);
+            }
+
+            if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+                if (this.selectedRow == 0) {
+                    // Playable Ship Features
+                    this.returnCode = 10; // Set return code for PlayableShipEditor
+                    this.isRunning = false;
+                } else if (this.selectedRow == 1) {
+                    // Enemy Ship Features
+                    drawManager.drawCenteredBigString(this, "Enemy Ship Features", getHeight() / 2);
+                }
+                this.selectionCooldown.reset();
+                soundManager.playSound(Sound.MENU_CLICK);
+            }
+
             if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE)) {
                 // Return to main menu or previous screen.
                 this.returnCode = 1;
                 this.isRunning = false;
                 soundManager.playSound(Sound.MENU_BACK);
             }
-            // Add more key events as needed for editor functionality
         }
     }
 
@@ -63,9 +97,14 @@ public class EditorScreen extends Screen {
     private void draw() {
         drawManager.initDrawing(this);
 
-        // Add drawing logic for editor screen
         drawManager.drawEditor(this);
+
+        // Draw buttons
+        String[] options = {"Playable Ship Features", "Enemy Ship Features"};
+        for (int i = 0; i < TOTAL_ROWS; i++) {
+            drawManager.drawCenteredRegularString(this, options[i], getHeight() / 2 + i * 40, selectedRow == i);
+        }
 
         drawManager.completeDrawing(this);
     }
-} 
+}

--- a/src/screen/EditorScreen.java
+++ b/src/screen/EditorScreen.java
@@ -1,29 +1,32 @@
 package screen;
 
-import java.awt.event.KeyEvent;
-import engine.Cooldown;
 import engine.Core;
+import engine.InputManager;
+import engine.SoundManager;
+import engine.Sound;
+
+import java.awt.event.KeyEvent;
 
 /**
  * Implements the editor screen.
  */
 public class EditorScreen extends Screen {
 
-    /** Time between changes in user selection. */
-    private static final int SELECTION_TIME = 200;
-    /** Cooldown for the selection change. */
-    private Cooldown selectionCooldown;
+    /** Singleton instance of SoundManager */
+    private final SoundManager soundManager = SoundManager.getInstance();
 
     /**
      * Constructor, establishes the properties of the screen.
      *
-     * @param width Screen width.
-     * @param height Screen height.
-     * @param fps Frames per second, frame rate at which the game is run.
+     * @param width
+     *            Screen width.
+     * @param height
+     *            Screen height.
+     * @param fps
+     *            Frames per second, frame rate at which the game is run.
      */
     public EditorScreen(final int width, final int height, final int fps) {
         super(width, height, fps);
-        this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
     }
 
     /**
@@ -31,17 +34,26 @@ public class EditorScreen extends Screen {
      *
      * @return Next screen code.
      */
-    public int run() {
+    public final int run() {
         super.run();
+        return this.returnCode;
+    }
 
-        while (true) {
-            draw();
-            if (this.inputDelay.checkFinished() && this.selectionCooldown.checkFinished()) {
-                if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE)) {
-                    return 1; // Return to main menu
-                }
-                // Add more key handling logic here for editor functionality
+    /**
+     * Updates the elements on screen and checks for events.
+     */
+    protected final void update() {
+        super.update();
+
+        draw();
+        if (this.inputDelay.checkFinished()) {
+            if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE)) {
+                // Return to main menu or previous screen.
+                this.returnCode = 1;
+                this.isRunning = false;
+                soundManager.playSound(Sound.MENU_BACK);
             }
+            // Add more key events as needed for editor functionality
         }
     }
 
@@ -50,7 +62,10 @@ public class EditorScreen extends Screen {
      */
     private void draw() {
         drawManager.initDrawing(this);
-        drawManager.drawCenteredBigString(this, "Editor Screen", this.height / 2);
+
+        // Add drawing logic for editor screen
+        drawManager.drawEditor(this);
+
         drawManager.completeDrawing(this);
     }
 } 


### PR DESCRIPTION
This pull request introduces a new feature for an editor screen in the application. The most important changes include adding a method to draw the editor screen, modifying the `EditorScreen` class to include new functionality, and updating the drawing logic for the editor screen.

New feature for editor screen:

* [`src/engine/DrawManager.java`](diffhunk://#diff-b96b0829110698c492022c12fd539b0dd6925531631653b4869b260acdda52e5R2059-R2075): Added the `drawEditor` method to handle drawing the editor screen, including setting the title and potential additional elements.

Modifications to `EditorScreen` class:

* [`src/screen/EditorScreen.java`](diffhunk://#diff-f5b9c53b6b071ac6f93e7bad211c2c1d87e90b6ccbaf54f0aede49d950390d37L3-R56): Added imports for `InputManager`, `SoundManager`, and `Sound`. Removed unused imports for `KeyEvent` and `Cooldown`. Introduced a singleton instance of `SoundManager`.
* [`src/screen/EditorScreen.java`](diffhunk://#diff-f5b9c53b6b071ac6f93e7bad211c2c1d87e90b6ccbaf54f0aede49d950390d37L53-R68): Modified the `run` method to call `super.run()` and return `this.returnCode`. Added the `update` method to handle screen updates and key events, including playing a sound when returning to the main menu.

Updates to drawing logic for editor screen:

* [`src/screen/EditorScreen.java`](diffhunk://#diff-f5b9c53b6b071ac6f93e7bad211c2c1d87e90b6ccbaf54f0aede49d950390d37L53-R68): Updated the `draw` method to call `drawManager.drawEditor` instead of drawing the editor screen title directly.
<img width="1512" alt="dd" src="https://github.com/user-attachments/assets/9faf5565-2ef4-4390-8e68-f7b57e1f8ad2">
